### PR TITLE
Use explicit maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<gson-version>2.5</gson-version>
 		<junit-version>4.12</junit-version>
         <lombok.version>1.16.20</lombok.version>
-        <jackson-databind.version>[2.9.9,)</jackson-databind.version>
+        <jackson-databind.version>2.9.9.3</jackson-databind.version>
 		<assertj.version>3.11.1</assertj.version>
 		
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Build is failing right now since it is resolving the dependency with version 3.0.0-SNAPSHOT, and that yields the error:
```
[ERROR] /var/lib/jenkins/workspace/INDIGO/qcg-client-publish/src/main/java/it/infn/ba/deep/qcg/client/utils/QcgEncoder.java:[43,13] error: cannot find symbol
[ERROR]   symbol:   method setSerializationInclusion(Include)
  location: variable mapper of type ObjectMapper
/var/lib/jenkins/workspace/INDIGO/qcg-client-publish/src/main/java/it/infn/ba/deep/qcg/client/utils/ModelUtils.java:[110,11] error: cannot find symbol
[ERROR]   symbol:   method setSerializationInclusion(Include)
  location: variable mapper of type ObjectMapper
/var/lib/jenkins/workspace/INDIGO/qcg-client-publish/src/main/java/it/infn/ba/deep/qcg/client/utils/QcgDecoder.java:[47,11] error: cannot find symbol
```